### PR TITLE
Add types to the package.json#exports RELEASE

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,14 @@
 	"type": "module",
 	"license": "MIT",
 	"exports": {
-		"require": "./dist/index.cjs",
-		"import": "./dist/index.mjs"
+		"require": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.cjs"
+		},
+		"import": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.mjs"
+		}
 	},
 	"types": "dist/index.d.ts",
 	"files": [


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/vue-sdk/issues/20


## Description
Add types to the package.json#exports 