### PR TITLE
Override web component sdk configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.0.3",
 			"license": "MIT",
 			"dependencies": {
-				"@descope/web-component": "3.7.0"
+				"@descope/web-component": "3.7.6"
 			},
 			"devDependencies": {
 				"@rollup/plugin-typescript": "^11.1.0",
@@ -1801,29 +1801,29 @@
 			}
 		},
 		"node_modules/@descope/web-component": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.0.tgz",
-			"integrity": "sha512-nMfCL6nixPHy9CKGbVtiKuG3t46J0oH5/bXG4FhERoXm20Ind/AkVHoSv+Smg0FRJIfJ/LquYS+SXP2M+B9zsA==",
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.6.tgz",
+			"integrity": "sha512-sjRhvfnhv1Wph4jZmiA8U5A1KZWkOXn82TeYDE0Mo/qavY+McA79VShLRoQm5kGWH4b/pNWcMlXtb1ajJhdBNg==",
 			"dependencies": {
-				"@descope/web-js-sdk": "1.9.0",
+				"@descope/web-js-sdk": "1.9.5",
 				"tslib": "2.6.2"
 			}
 		},
 		"node_modules/@descope/web-component/node_modules/@descope/core-js-sdk": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.8.0.tgz",
-			"integrity": "sha512-2MTgEInuLGSPsfnnMxaEInp7JyQjHhHU++TEoLhaoX0jmDT2tWrCLh6Lgyv5sSfST957T6CPxBSjjG9ItwTRKA==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.9.1.tgz",
+			"integrity": "sha512-pnj390un0HbdIFDsVeHHWmwjsBx0sJOwrrsoyZEi4W7jBBUmOfKCq1Rs4oNQgjuklWHmjqQKFLIm+rafOH8z3w==",
 			"dependencies": {
 				"jwt-decode": "3.1.2",
 				"lodash.get": "4.4.2"
 			}
 		},
 		"node_modules/@descope/web-component/node_modules/@descope/web-js-sdk": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.0.tgz",
-			"integrity": "sha512-ESBLVf/Edmo2joUATy16mnXXmJ/MjyPQg+LuvMNN8Ngpnvli23C9eHo3Z+XxSkflzcV3KhtpOCNyxmbjRR2u2g==",
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.5.tgz",
+			"integrity": "sha512-4i/1iHDC/B6U97Jyh9n6lFFnqi2apEVR8P9zkUToLn4luBlX/dX18QTlylZIjXaVtW29NkkRnpsoNGDwqsYLuQ==",
 			"dependencies": {
-				"@descope/core-js-sdk": "2.8.0",
+				"@descope/core-js-sdk": "2.9.1",
 				"@fingerprintjs/fingerprintjs-pro": "3.8.5",
 				"js-cookie": "3.0.5",
 				"tslib": "2.6.2"
@@ -19535,29 +19535,29 @@
 			}
 		},
 		"@descope/web-component": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.0.tgz",
-			"integrity": "sha512-nMfCL6nixPHy9CKGbVtiKuG3t46J0oH5/bXG4FhERoXm20Ind/AkVHoSv+Smg0FRJIfJ/LquYS+SXP2M+B9zsA==",
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.6.tgz",
+			"integrity": "sha512-sjRhvfnhv1Wph4jZmiA8U5A1KZWkOXn82TeYDE0Mo/qavY+McA79VShLRoQm5kGWH4b/pNWcMlXtb1ajJhdBNg==",
 			"requires": {
-				"@descope/web-js-sdk": "1.9.0",
+				"@descope/web-js-sdk": "1.9.5",
 				"tslib": "2.6.2"
 			},
 			"dependencies": {
 				"@descope/core-js-sdk": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.8.0.tgz",
-					"integrity": "sha512-2MTgEInuLGSPsfnnMxaEInp7JyQjHhHU++TEoLhaoX0jmDT2tWrCLh6Lgyv5sSfST957T6CPxBSjjG9ItwTRKA==",
+					"version": "2.9.1",
+					"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.9.1.tgz",
+					"integrity": "sha512-pnj390un0HbdIFDsVeHHWmwjsBx0sJOwrrsoyZEi4W7jBBUmOfKCq1Rs4oNQgjuklWHmjqQKFLIm+rafOH8z3w==",
 					"requires": {
 						"jwt-decode": "3.1.2",
 						"lodash.get": "4.4.2"
 					}
 				},
 				"@descope/web-js-sdk": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.0.tgz",
-					"integrity": "sha512-ESBLVf/Edmo2joUATy16mnXXmJ/MjyPQg+LuvMNN8Ngpnvli23C9eHo3Z+XxSkflzcV3KhtpOCNyxmbjRR2u2g==",
+					"version": "1.9.5",
+					"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.5.tgz",
+					"integrity": "sha512-4i/1iHDC/B6U97Jyh9n6lFFnqi2apEVR8P9zkUToLn4luBlX/dX18QTlylZIjXaVtW29NkkRnpsoNGDwqsYLuQ==",
 					"requires": {
-						"@descope/core-js-sdk": "2.8.0",
+						"@descope/core-js-sdk": "2.9.1",
 						"@fingerprintjs/fingerprintjs-pro": "3.8.5",
 						"js-cookie": "3.0.5",
 						"tslib": "2.6.2"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		]
 	},
 	"dependencies": {
-		"@descope/web-component": "3.7.0"
+		"@descope/web-component": "3.7.6"
 	},
 	"peerDependencies": {
 		"vue": ">=3"

--- a/src/Descope.vue
+++ b/src/Descope.vue
@@ -27,8 +27,28 @@ import { useOptions, useDescope } from './hooks';
 import { baseHeaders } from './constants';
 import { RequestConfig } from '@descope/core-js-sdk';
 import { computed } from 'vue';
+import { getGlobalSdk } from './sdk';
 
-DescopeWcClass.sdkConfigOverrides = { baseHeaders };
+DescopeWcClass.sdkConfigOverrides = {
+	// Overrides the web-component's base headers to indicate usage via the React SDK
+	baseHeaders,
+	// Disables token persistence within the web-component to delegate token management
+	// to the global SDK hooks. This ensures token handling aligns with the SDK's configuration,
+	// and web-component requests leverage the global SDK's beforeRequest hooks for consistency
+	persistTokens: false,
+	hooks: {
+		get beforeRequest() {
+			// Retrieves the beforeRequest hook from the global SDK, which is initialized
+			// within the AuthProvider using the desired configuration. This approach ensures
+			// the web-component utilizes the same beforeRequest hooks as the global SDK
+			return getGlobalSdk().httpClient.hooks.beforeRequest;
+		},
+		set beforeRequest(_) {
+			// The empty setter prevents runtime errors when attempts are made to assign a value to 'beforeRequest'.
+			// JavaScript objects default to having both getters and setters
+		}
+	}
+};
 
 const props = defineProps({
 	flowId: {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,7 +3,7 @@ import { IS_BROWSER } from './constants';
 import { wrapInTry } from './utils';
 
 type Sdk = ReturnType<typeof createSdkWrapper>;
-let sdkInstance: Sdk;
+let globalSdk: Sdk;
 
 const createSdkWrapper = <P extends Parameters<typeof createSdk>[0]>(
 	config: P
@@ -13,7 +13,7 @@ const createSdkWrapper = <P extends Parameters<typeof createSdk>[0]>(
 		persistTokens: IS_BROWSER as true,
 		autoRefresh: IS_BROWSER as true
 	});
-	sdkInstance = sdk;
+	globalSdk = sdk;
 
 	return sdk;
 };
@@ -25,11 +25,11 @@ const createSdkWrapper = <P extends Parameters<typeof createSdk>[0]>(
  * and we are creating a temp instance in order to export the getSessionToken
  * even before the SDK was init
  */
-sdkInstance = createSdkWrapper({ projectId: 'temp pid' });
+globalSdk = createSdkWrapper({ projectId: 'temp pid' });
 
 export const getSessionToken = () => {
 	if (IS_BROWSER) {
-		return sdkInstance?.getSessionToken();
+		return globalSdk?.getSessionToken();
 	}
 
 	// eslint-disable-next-line no-console
@@ -39,7 +39,7 @@ export const getSessionToken = () => {
 
 export const getRefreshToken = () => {
 	if (IS_BROWSER) {
-		return sdkInstance?.getRefreshToken();
+		return globalSdk?.getRefreshToken();
 	}
 	// eslint-disable-next-line no-console
 	console.warn('Get refresh token is not supported in SSR');
@@ -48,15 +48,16 @@ export const getRefreshToken = () => {
 
 export const getJwtPermissions = wrapInTry(
 	(token = getSessionToken(), tenant?: string) =>
-		sdkInstance?.getJwtPermissions(token, tenant)
+		globalSdk?.getJwtPermissions(token, tenant)
 );
 
 export const getJwtRoles = wrapInTry(
 	(token = getSessionToken(), tenant?: string) =>
-		sdkInstance?.getJwtRoles(token, tenant)
+		globalSdk?.getJwtRoles(token, tenant)
 );
 
-export const refresh = (token = getRefreshToken()) =>
-	sdkInstance?.refresh(token);
+export const refresh = (token = getRefreshToken()) => globalSdk?.refresh(token);
+
+export const getGlobalSdk = () => globalSdk;
 
 export default createSdkWrapper;

--- a/tests/Descope.test.ts
+++ b/tests/Descope.test.ts
@@ -1,5 +1,6 @@
 import { shallowMount, mount } from '@vue/test-utils';
 import { Descope } from '../src';
+import { default as DescopeWC } from '@descope/web-component';
 
 jest.mock('../src/hooks', () => ({
 	useOptions: () => ({ projectId: 'project1', baseUrl: 'baseUrl' }),
@@ -66,6 +67,23 @@ describe('Descope.vue', () => {
 		const descopeWc = wrapper.find('descope-wc');
 		expect(descopeWc.attributes('form')).toBe('');
 		expect(wrapper.vm.client).toBeNull();
+	});
+
+	it('init sdk config', async () => {
+		const wrapper = mount(Descope);
+		const descopeWc = wrapper.find('descope-wc');
+		expect(descopeWc).toBeTruthy();
+
+		expect(DescopeWC.sdkConfigOverrides).toEqual({
+			baseHeaders: {
+				'x-descope-sdk-name': 'vue',
+				'x-descope-sdk-version': '123'
+			},
+			persistTokens: false,
+			hooks: {
+				beforeRequest: expect.any(Function)
+			}
+		});
 	});
 
 	it('emits a success event when the DescopeWc component emits a success event', async () => {


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/5319

## Related PRs

https://github.com/descope/descope-js/pull/356


## Description
Override web component sdk configs so that the hooks running before will run in the same manner

same as https://github.com/descope/react-sdk/pull/456