### PR TITLE
Add session and refresh token expiration utilities RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ You can also use the following functions to assist with various actions managing
 `getSessionToken()` - Get current session token.
 `getRefreshToken()` - Get current refresh token.
 `refresh(token = getRefreshToken())` - Force a refresh on current session token using an existing valid refresh token.
+`isSessionTokenExpired(token = getSessionToken())` - Check whether the current session token is expired. Provide a session token if is not persisted.
+`isRefreshTokenExpired(token = getRefreshToken())` - Check whether the current refresh token is expired. Provide a refresh token if is not persisted.
 `getJwtRoles(token = getSessionToken(), tenant = '')` - Get current roles from an existing session token. Provide tenant id for specific tenant roles.
 `getJwtPermissions(token = getSessionToken(), tenant = '')` - Fet current permissions from an existing session token. Provide tenant id for specific tenant permissions.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,7 @@ export {
 	getJwtPermissions,
 	getJwtRoles,
 	getRefreshToken,
-	getSessionToken
+	getSessionToken,
+	isSessionTokenExpired,
+	isRefreshTokenExpired
 } from './sdk';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -46,6 +46,12 @@ export const getRefreshToken = () => {
 	return '';
 };
 
+export const isSessionTokenExpired = (token = getSessionToken()) =>
+	globalSdk?.isJwtExpired(token);
+
+export const isRefreshTokenExpired = (token = getRefreshToken()) =>
+	globalSdk?.isJwtExpired(token);
+
 export const getJwtPermissions = wrapInTry(
 	(token = getSessionToken(), tenant?: string) =>
 		globalSdk?.getJwtPermissions(token, tenant)

--- a/tests/utilityFunctions.test.ts
+++ b/tests/utilityFunctions.test.ts
@@ -1,0 +1,126 @@
+import createSdk, {
+	refresh,
+	getJwtPermissions,
+	getJwtRoles,
+	getRefreshToken,
+	getSessionToken,
+	isSessionTokenExpired,
+	isRefreshTokenExpired
+} from '../src/sdk';
+
+jest.mock('@descope/web-js-sdk', () => () => ({
+	getSessionToken: jest.fn(),
+	getRefreshToken: jest.fn(),
+	isJwtExpired: jest.fn(),
+	getJwtPermissions: jest.fn(),
+	getJwtRoles: jest.fn(),
+	refresh: jest.fn()
+}));
+
+const sdk = createSdk({ projectId: 'test' });
+
+describe('utility functions', () => {
+	it('should call getSessionToken from sdk', () => {
+		getSessionToken();
+		expect(sdk.getSessionToken).toHaveBeenCalled();
+	});
+
+	it('should warn when using getSessionToken in non browser environment', () => {
+		const warnSpy = jest.spyOn(console, 'warn');
+
+		const origWindow = window;
+		Object.defineProperty(global, 'window', {
+			value: undefined,
+			writable: true,
+			configurable: true
+		});
+
+		jest.resetModules();
+
+		// eslint-disable-next-line  @typescript-eslint/no-var-requires
+		const { getSessionToken: getSessionTokenLocal } = require('../src/sdk');
+
+		getSessionTokenLocal();
+
+		global.window = origWindow;
+		jest.resetModules();
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'Get session token is not supported in SSR'
+		);
+		expect(sdk.getSessionToken).not.toHaveBeenCalled();
+	});
+
+	it('should call getRefreshToken from sdk', () => {
+		getRefreshToken();
+		expect(sdk.getRefreshToken).toHaveBeenCalled();
+	});
+
+	it('should warn when using getRefreshToken in non browser environment', () => {
+		const warnSpy = jest.spyOn(console, 'warn');
+
+		const origWindow = window;
+		Object.defineProperty(global, 'window', {
+			value: undefined,
+			writable: true,
+			configurable: true
+		});
+
+		jest.resetModules();
+
+		// eslint-disable-next-line  @typescript-eslint/no-var-requires
+		const { getRefreshToken: getRefreshTokenLocal } = require('../src/sdk');
+
+		getRefreshTokenLocal();
+
+		global.window = origWindow;
+		jest.resetModules();
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'Get refresh token is not supported in SSR'
+		);
+		expect(sdk.getRefreshToken).not.toHaveBeenCalled();
+	});
+
+	it('should call refresh token with the session token', async () => {
+		(sdk.refresh as jest.Mock).getMockImplementation();
+		await refresh('test');
+		expect(sdk.refresh).toHaveBeenCalledWith('test');
+	});
+
+	it('should call getJwtPermissions with the session token when not provided', () => {
+		(sdk.getSessionToken as jest.Mock).mockReturnValueOnce('session');
+		getJwtPermissions();
+		expect(sdk.getJwtPermissions).toHaveBeenCalledWith('session', undefined);
+	});
+
+	it('should call isSessionJwtExpired with the session token when not provided', () => {
+		(sdk.getSessionToken as jest.Mock).mockReturnValueOnce('session');
+		jest.spyOn(sdk, 'isJwtExpired').mockReturnValueOnce(false);
+		isSessionTokenExpired();
+		expect(sdk.isJwtExpired).toHaveBeenCalledWith('session');
+	});
+
+	it('should call isRefreshJwtExpired with the refresh token when not provided', () => {
+		(sdk.getRefreshToken as jest.Mock).mockReturnValueOnce('refresh');
+		jest.spyOn(sdk, 'isJwtExpired').mockReturnValueOnce(false);
+		isRefreshTokenExpired();
+		expect(sdk.isJwtExpired).toHaveBeenCalledWith('refresh');
+	});
+
+	it('should call getJwtRoles with the session token when not provided', () => {
+		(sdk.getSessionToken as jest.Mock).mockReturnValueOnce('session');
+		jest.spyOn(sdk, 'getJwtRoles').mockReturnValueOnce([]);
+		getJwtRoles();
+		expect(sdk.getJwtRoles).toHaveBeenCalledWith('session', undefined);
+	});
+
+	it('should call getJwtRoles with the session token when not provided', () => {
+		jest.spyOn(console, 'error').mockImplementation(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+		jest.spyOn(sdk, 'getJwtRoles').mockImplementation(() => {
+			throw new Error('session token');
+		});
+		getJwtRoles();
+		expect(console.error).toHaveBeenCalled(); // eslint-disable-line no-console
+	});
+});


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/6151

## Description

Add session and refresh token expiration utilities

## Must

- [x] Tests
- [x] Documentation (if applicable)
